### PR TITLE
Update the Caddy config for uptime.x

### DIFF
--- a/templates/dia-Caddyfile.j2
+++ b/templates/dia-Caddyfile.j2
@@ -77,12 +77,7 @@ api.invidious.io {
 uptime.invidio.us {
   import common
   import block-robots
-  redir https://stats.uptimerobot.com/89VnzSKAn{uri}
-}
-uptime.invidious.io {
-  import common
-  import block-robots
-  redir https://stats.uptimerobot.com/89VnzSKAn{uri}
+  redir https://uptime.invidious.io{uri}
 }
 
 docs.invidious.io {


### PR DESCRIPTION
uptime.invidious.io is now a CNAME